### PR TITLE
Add support for AA 66 heater controller

### DIFF
--- a/components/diesel_heater_ble/controllers.h
+++ b/components/diesel_heater_ble/controllers.h
@@ -21,7 +21,10 @@ class HeaterController {
   virtual std::vector<Request> get_auto_mode_command(HeaterState state) = 0;
 };
 
-class HeaterControllerAA55E : public HeaterController {
+class HeaterControllerAA : public HeaterController {
+ // It's assumed that AA55 and AA66 have the same command structure, whether encrypted or not.
+ // However specific heater controller classes are below for implementing differences as needed.
+
  public:
   std::vector<Request> change_mode_command(HeaterState state, uint8_t target_mode) {
     std::vector<Request> requests;
@@ -97,12 +100,22 @@ class HeaterControllerAA55E : public HeaterController {
   std::vector<Request> get_auto_mode_command(HeaterState state) override { return change_mode_command(state, 0x02); }
 };
 
+class HeaterControllerAA55E : public HeaterControllerAA {
+  // Specific implementation for AA55 Encrypted if needed in future.
+};
+
+class HeaterControllerAA66 : public HeaterControllerAA {
+  // Specific implementation for AA66 if needed in future.
+};
+
 class ControllerSelector {
  public:
   static HeaterController *get_controller(HeaterClass heater_class) {
     switch (heater_class) {
       case HeaterClass::HEATER_AA_55_ENCRYPTED:
         return new HeaterControllerAA55E();
+      case HeaterClass::HEATER_AA_66:
+        return new HeaterControllerAA66();
       default:
         return nullptr;
     }


### PR DESCRIPTION
Hi, firstly thank you for this awesome project!

In getting it to work with my heater, I discovered my header is 0xAA, 0x66, not encrypted. I tried using your existing AA55E heater controller and all commands work exactly as expected!

I took a look through the original apk's code and it seems there is no difference in the control command structure between the different heaters supported by airheaterble app, so I slightly restructured the heater controller class so it's easy to add support for the 4 versions that app supports, while still allowing future support for entirely different command structures, as well as slight changes to the 4 known versions if necessary.

I've only tested this with my own heater which is AA66, but this shouldn't affect AA55E