### PR TITLE
Don't publish states for unavailable entities

### DIFF
--- a/components/diesel_heater_ble/controllers.h
+++ b/components/diesel_heater_ble/controllers.h
@@ -74,9 +74,9 @@ class HeaterControllerAA55E : public HeaterController {
 
   std::vector<Request> gen_temp_up_command(HeaterState state) override {
     auto requests = get_auto_mode_command(state);
-    if (state.tempunit == 0x00 && state.settemp < 36) {
+    if (state.extras.tempunit == 0x00 && state.settemp < 36) {
       requests.push_back(Request(0x04, state.settemp + 1, 0x00));
-    } else if (state.tempunit == 0x01 && state.settemp < 97) {
+    } else if (state.extras.tempunit == 0x01 && state.settemp < 97) {
       requests.push_back(Request(0x04, state.settemp + 1, 0x00));
     }
     return requests;
@@ -84,9 +84,9 @@ class HeaterControllerAA55E : public HeaterController {
 
   std::vector<Request> gen_temp_down_command(HeaterState state) override {
     auto requests = get_auto_mode_command(state);
-    if (state.tempunit == 0x00 && state.settemp > 8) {
+    if (state.extras.tempunit == 0x00 && state.settemp > 8) {
       requests.push_back(Request(0x04, state.settemp - 1, 0x00));
-    } else if (state.tempunit == 0x01 && state.settemp > 46) {
+    } else if (state.extras.tempunit == 0x01 && state.settemp > 46) {
       requests.push_back(Request(0x04, state.settemp - 1, 0x00));
     }
     return requests;

--- a/components/diesel_heater_ble/heater.cpp
+++ b/components/diesel_heater_ble/heater.cpp
@@ -174,53 +174,55 @@ void DieselHeaterBLE::update_sensors(const HeaterState &new_state) {
     cab_temp_->publish_state(new_state.cabtemp);
     return;
   }
-  if (start_time_ != nullptr && start_time_->state != new_state.extras.sttime) {
-    start_time_->publish_state(new_state.extras.sttime);
-    return;
-  }
-  if (auto_time_ != nullptr && auto_time_->state != new_state.extras.autotime) {
-    auto_time_->publish_state(new_state.extras.autotime);
-    return;
-  }
-  if (run_time_ != nullptr && run_time_->state != new_state.extras.runtime) {
-    run_time_->publish_state(new_state.extras.runtime);
-    return;
-  }
-  if (is_auto_ != nullptr && is_auto_->state != new_state.extras.isauto) {
-    is_auto_->publish_state(new_state.extras.isauto);
-    return;
-  }
-  if (language_ != nullptr && language_->state != new_state.extras.language) {
-    language_->publish_state(new_state.extras.language);
-    return;
-  }
-  if (temp_offset_ != nullptr && temp_offset_->state != new_state.extras.tempoffset) {
-    temp_offset_->publish_state(new_state.extras.tempoffset);
-    return;
-  }
-  if (tank_volume_ != nullptr && tank_volume_->state != new_state.extras.tankvolume) {
-    tank_volume_->publish_state(new_state.extras.tankvolume);
-    return;
-  }
-  if (oil_pump_type_ != nullptr && oil_pump_type_->state != new_state.extras.oilpumptype) {
-    oil_pump_type_->publish_state(new_state.extras.oilpumptype);
-    return;
-  }
-  if (rf433_on_off_ != nullptr && rf433_on_off_->state != static_cast<float>(new_state.extras.rf433onoff)) {
-    rf433_on_off_->publish_state(new_state.extras.rf433onoff);
-    return;
-  }
-  if (temp_unit_ != nullptr && temp_unit_->state != new_state.extras.tempunit) {
-    temp_unit_->publish_state(new_state.extras.tempunit);
-    return;
-  }
-  if (altitude_unit_ != nullptr && altitude_unit_->state != new_state.extras.altiunit) {
-    altitude_unit_->publish_state(new_state.extras.altiunit);
-    return;
-  }
-  if (automatic_heating_ != nullptr && automatic_heating_->state != new_state.extras.automaticheating) {
-    automatic_heating_->publish_state(new_state.extras.automaticheating);
-    return;
+  if (new_state.extras.has_extras) {
+    if (start_time_ != nullptr && start_time_->state != new_state.extras.sttime) {
+      start_time_->publish_state(new_state.extras.sttime);
+      return;
+    }
+    if (auto_time_ != nullptr && auto_time_->state != new_state.extras.autotime) {
+      auto_time_->publish_state(new_state.extras.autotime);
+      return;
+    }
+    if (run_time_ != nullptr && run_time_->state != new_state.extras.runtime) {
+      run_time_->publish_state(new_state.extras.runtime);
+      return;
+    }
+    if (is_auto_ != nullptr && is_auto_->state != new_state.extras.isauto) {
+      is_auto_->publish_state(new_state.extras.isauto);
+      return;
+    }
+    if (language_ != nullptr && language_->state != new_state.extras.language) {
+      language_->publish_state(new_state.extras.language);
+      return;
+    }
+    if (temp_offset_ != nullptr && temp_offset_->state != new_state.extras.tempoffset) {
+      temp_offset_->publish_state(new_state.extras.tempoffset);
+      return;
+    }
+    if (tank_volume_ != nullptr && tank_volume_->state != new_state.extras.tankvolume) {
+      tank_volume_->publish_state(new_state.extras.tankvolume);
+      return;
+    }
+    if (oil_pump_type_ != nullptr && oil_pump_type_->state != new_state.extras.oilpumptype) {
+      oil_pump_type_->publish_state(new_state.extras.oilpumptype);
+      return;
+    }
+    if (rf433_on_off_ != nullptr && rf433_on_off_->state != static_cast<float>(new_state.extras.rf433onoff)) {
+      rf433_on_off_->publish_state(new_state.extras.rf433onoff);
+      return;
+    }
+    if (temp_unit_ != nullptr && temp_unit_->state != new_state.extras.tempunit) {
+      temp_unit_->publish_state(new_state.extras.tempunit);
+      return;
+    }
+    if (altitude_unit_ != nullptr && altitude_unit_->state != new_state.extras.altiunit) {
+      altitude_unit_->publish_state(new_state.extras.altiunit);
+      return;
+    }
+    if (automatic_heating_ != nullptr && automatic_heating_->state != new_state.extras.automaticheating) {
+      automatic_heating_->publish_state(new_state.extras.automaticheating);
+      return;
+    }
   }
 }
 

--- a/components/diesel_heater_ble/heater.cpp
+++ b/components/diesel_heater_ble/heater.cpp
@@ -174,52 +174,52 @@ void DieselHeaterBLE::update_sensors(const HeaterState &new_state) {
     cab_temp_->publish_state(new_state.cabtemp);
     return;
   }
-  if (start_time_ != nullptr && start_time_->state != new_state.sttime) {
-    start_time_->publish_state(new_state.sttime);
+  if (start_time_ != nullptr && start_time_->state != new_state.extras.sttime) {
+    start_time_->publish_state(new_state.extras.sttime);
     return;
   }
-  if (auto_time_ != nullptr && auto_time_->state != new_state.autotime) {
-    auto_time_->publish_state(new_state.autotime);
+  if (auto_time_ != nullptr && auto_time_->state != new_state.extras.autotime) {
+    auto_time_->publish_state(new_state.extras.autotime);
     return;
   }
-  if (run_time_ != nullptr && run_time_->state != new_state.runtime) {
-    run_time_->publish_state(new_state.runtime);
+  if (run_time_ != nullptr && run_time_->state != new_state.extras.runtime) {
+    run_time_->publish_state(new_state.extras.runtime);
     return;
   }
-  if (is_auto_ != nullptr && is_auto_->state != new_state.isauto) {
-    is_auto_->publish_state(new_state.isauto);
+  if (is_auto_ != nullptr && is_auto_->state != new_state.extras.isauto) {
+    is_auto_->publish_state(new_state.extras.isauto);
     return;
   }
-  if (language_ != nullptr && language_->state != new_state.language) {
-    language_->publish_state(new_state.language);
+  if (language_ != nullptr && language_->state != new_state.extras.language) {
+    language_->publish_state(new_state.extras.language);
     return;
   }
-  if (temp_offset_ != nullptr && temp_offset_->state != new_state.tempoffset) {
-    temp_offset_->publish_state(new_state.tempoffset);
+  if (temp_offset_ != nullptr && temp_offset_->state != new_state.extras.tempoffset) {
+    temp_offset_->publish_state(new_state.extras.tempoffset);
     return;
   }
-  if (tank_volume_ != nullptr && tank_volume_->state != new_state.tankvolume) {
-    tank_volume_->publish_state(new_state.tankvolume);
+  if (tank_volume_ != nullptr && tank_volume_->state != new_state.extras.tankvolume) {
+    tank_volume_->publish_state(new_state.extras.tankvolume);
     return;
   }
-  if (oil_pump_type_ != nullptr && oil_pump_type_->state != new_state.oilpumptype) {
-    oil_pump_type_->publish_state(new_state.oilpumptype);
+  if (oil_pump_type_ != nullptr && oil_pump_type_->state != new_state.extras.oilpumptype) {
+    oil_pump_type_->publish_state(new_state.extras.oilpumptype);
     return;
   }
-  if (rf433_on_off_ != nullptr && rf433_on_off_->state != static_cast<float>(new_state.rf433onoff)) {
-    rf433_on_off_->publish_state(new_state.rf433onoff);
+  if (rf433_on_off_ != nullptr && rf433_on_off_->state != static_cast<float>(new_state.extras.rf433onoff)) {
+    rf433_on_off_->publish_state(new_state.extras.rf433onoff);
     return;
   }
-  if (temp_unit_ != nullptr && temp_unit_->state != new_state.tempunit) {
-    temp_unit_->publish_state(new_state.tempunit);
+  if (temp_unit_ != nullptr && temp_unit_->state != new_state.extras.tempunit) {
+    temp_unit_->publish_state(new_state.extras.tempunit);
     return;
   }
-  if (altitude_unit_ != nullptr && altitude_unit_->state != new_state.altiunit) {
-    altitude_unit_->publish_state(new_state.altiunit);
+  if (altitude_unit_ != nullptr && altitude_unit_->state != new_state.extras.altiunit) {
+    altitude_unit_->publish_state(new_state.extras.altiunit);
     return;
   }
-  if (automatic_heating_ != nullptr && automatic_heating_->state != new_state.automaticheating) {
-    automatic_heating_->publish_state(new_state.automaticheating);
+  if (automatic_heating_ != nullptr && automatic_heating_->state != new_state.extras.automaticheating) {
+    automatic_heating_->publish_state(new_state.extras.automaticheating);
     return;
   }
 }

--- a/components/diesel_heater_ble/messages.h
+++ b/components/diesel_heater_ble/messages.h
@@ -106,22 +106,26 @@ class ResponseParser {
 
     // encrypted types only
     if (heater_class == HeaterClass::HEATER_AA_55_ENCRYPTED || heater_class == HeaterClass::HEATER_AA_66_ENCRYPTED) {
-      state.sttime = decrypted[20] + (decrypted[19] << 8);
-      state.autotime = decrypted[22] + (decrypted[21] << 8);
-      state.runtime = decrypted[24] + (decrypted[23] << 8);
-      state.isauto = decrypted[25];
-      state.language = decrypted[26];
-      state.tempoffset = decrypted[34];
-      state.tankvolume = decrypted[28];
-      state.oilpumptype = decrypted[29];
+      state.extras.sttime = decrypted[20] + (decrypted[19] << 8);
+      state.extras.autotime = decrypted[22] + (decrypted[21] << 8);
+      state.extras.runtime = decrypted[24] + (decrypted[23] << 8);
+      state.extras.isauto = decrypted[25];
+      state.extras.language = decrypted[26];
+      state.extras.tempoffset = decrypted[34];
+      state.extras.tankvolume = decrypted[28];
+      state.extras.oilpumptype = decrypted[29];
       if (raw[29] == 20) {
-        state.rf433onoff = false;
+        state.extras.rf433onoff = false;
       } else if (raw[29] == 21) {
-        state.rf433onoff = true;
+        state.extras.rf433onoff = true;
       }
-      state.tempunit = decrypted[27];
-      state.altiunit = decrypted[30];
-      state.automaticheating = decrypted[31];
+      state.extras.tempunit = decrypted[27];
+      state.extras.altiunit = decrypted[30];
+      state.extras.automaticheating = decrypted[31];
+
+      state.extras.has_extras = true;
+    } else {
+      state.extras.has_extras = false;
     }
 
     return true;

--- a/components/diesel_heater_ble/state.h
+++ b/components/diesel_heater_ble/state.h
@@ -30,6 +30,7 @@ class HeaterState {
   uint16_t cabtemp;
 
   // encoded types only
+  struct {
   uint16_t sttime;
   uint16_t autotime;
   uint16_t runtime;
@@ -42,10 +43,12 @@ class HeaterState {
   uint8_t tempunit;
   uint8_t altiunit;
   uint8_t automaticheating;
+  bool has_extras = false;
+  } extras;
 
   // return table format of data with columnt names
   std::string to_string() {
-    return "HeaterState: \n"
+    std::string table = "HeaterState: \n"
            "  heater_class: " +
            std::to_string(static_cast<int>(heater_class)) +
            "\n"
@@ -81,18 +84,21 @@ class HeaterState {
            "\n"
            "  cabtemp: " +
            std::to_string(cabtemp) +
-           "\n"
-           "  sttime: " +
-           std::to_string(sttime) +
-           "\n"
-           "  autotime: " +
-           std::to_string(autotime) +
-           "\n"
-           "  runtime: " +
-           std::to_string(runtime) +
-           "\n"
-           "  isauto: " +
-           std::to_string(isauto) + "\n";
+           "\n";
+      if (extras.has_extras) {
+        table += "  sttime: " +
+            std::to_string(extras.sttime) +
+            "\n"
+            "  autotime: " +
+            std::to_string(extras.autotime) +
+            "\n"
+            "  runtime: " +
+            std::to_string(extras.runtime) +
+            "\n"
+            "  isauto: " +
+            std::to_string(extras.isauto) + "\n";
+          }
+    return table;
   }
 };
 


### PR DESCRIPTION
I discovered that as my heater doesn't use an encrypted protocol, it's missing several extra sensors, and the component was erroneously publishing zero values for those sensors. This made it difficult to determine whether that sensor was actually 0 or unknown.

This change slightly restructures these extra entities to make it obvious they're not always included, and ensures those entities are not published when the underlying data doesn't exist.

Before (notice all the 0s and the 32f temp offset):

<img width="338" height="884" alt="Screenshot from 2025-10-09 04-47-25" src="https://github.com/user-attachments/assets/1a6dda07-674e-4c83-a35d-0566513a44d5" />

After (correctly marked as unknown):
<img width="338" height="884" alt="Screenshot from 2025-10-09 05-14-39" src="https://github.com/user-attachments/assets/3bedecf9-732f-4ee2-a4fa-c3fa6a19e716" />
