### PR TITLE
Fix encrypted heater class detection

### DIFF
--- a/components/diesel_heater_ble/messages.h
+++ b/components/diesel_heater_ble/messages.h
@@ -37,8 +37,10 @@ class ResponseParser {
         return HeaterClass::HEATER_AA_55;
       case 0x66:
         return HeaterClass::HEATER_AA_66;
-      case 0x07:
+      case 0x34: // 0x55 ^ 97
         return HeaterClass::HEATER_AA_55_ENCRYPTED;
+      case 0x07: // 0x66 ^ 97
+        return HeaterClass::HEATER_AA_66_ENCRYPTED;
       default:
         return HeaterClass::HEATER_CLASS_UNKNOWN;
     }


### PR DESCRIPTION
When initially troubleshooting why my heater wasn't working with this integration I discovered 2 related issues:

- There was no detection for AA_66 encrypted
- The detection for AA_55 encrypted was using the wrong value, it was using the encrypted 0x66 value instead.

This has the implication that encrypted 0x66 heaters were detected as AA_55_ENCRYPTED, which is not going to break any sensors except `errcode`, and that one would be hard to notice. This also implies that actual encrypted 0x55 heaters would not work at all with this bug.

The other implication is that I think it means you've been mislead about which protocol your heater has been using this whole time, if your readme is correct that you thought you have been using this with an encrypted 0x55 heater.


I can't test this as I don't have an encrypted variant, but this should be easy to test with yours, just ensure your `errcode` value updates correctly if you manually create an error condition by unplugging your fuel pump.