### PR TITLE
Automatically set the clock on the heater

### DIFF
--- a/components/diesel_heater_ble/__init__.py
+++ b/components/diesel_heater_ble/__init__.py
@@ -1,5 +1,5 @@
 import esphome.codegen as cg
-from esphome.components import ble_client, sensor
+from esphome.components import ble_client, sensor, time as time_
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
 
@@ -7,6 +7,7 @@ CODEOWNERS = ["@warehog"]
 DEPENDENCIES = ["ble_client"]
 
 CONF_DIESEL_HEATER_BLE = "diesel_heater_ble"
+CONF_TIME_ID = "time_id"
 
 diesel_heater_ble_ns = cg.esphome_ns.namespace("diesel_heater_ble")
 DieselHeaterBLE = diesel_heater_ble_ns.class_(
@@ -14,7 +15,10 @@ DieselHeaterBLE = diesel_heater_ble_ns.class_(
 )
 
 CONFIG_SCHEMA = (
-    cv.Schema({cv.GenerateID(): cv.declare_id(DieselHeaterBLE)})
+    cv.Schema({
+        cv.GenerateID(): cv.declare_id(DieselHeaterBLE),
+        cv.Required(CONF_TIME_ID): cv.use_id(time_.RealTimeClock),
+    })
     .extend(cv.COMPONENT_SCHEMA)
     .extend(ble_client.BLE_CLIENT_SCHEMA)
 )
@@ -24,3 +28,5 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await ble_client.register_ble_node(var, config)
+    time_var = await cg.get_variable(config[CONF_TIME_ID])
+    cg.add(var.set_time(time_var))

--- a/components/diesel_heater_ble/controllers.h
+++ b/components/diesel_heater_ble/controllers.h
@@ -10,6 +10,7 @@ namespace diesel_heater_ble {
 
 class HeaterController {
  public:
+  virtual std::vector<Request> gen_time_command(uint8_t hours, uint8_t minutes) = 0;
   virtual std::vector<Request> gen_power_command(HeaterState state, bool power) = 0;
   virtual std::vector<Request> gen_level_command(HeaterState state, uint8_t value) = 0;
   virtual std::vector<Request> gen_level_up_command(HeaterState state) = 0;
@@ -32,6 +33,12 @@ class HeaterControllerAA55E : public HeaterController {
   }
 
  public:
+  std::vector<Request> gen_time_command(uint8_t hours, uint8_t minutes) override {
+    std::vector<Request> requests;
+    requests.push_back(Request(0x0A, hours * 60 + minutes));
+    return requests;
+  }
+
   std::vector<Request> gen_power_command(HeaterState state, bool power) override {
     std::vector<Request> requests;
     if (state.runningstate != power) {

--- a/components/diesel_heater_ble/heater.cpp
+++ b/components/diesel_heater_ble/heater.cpp
@@ -111,6 +111,14 @@ void DieselHeaterBLE::on_notification_received(const std::vector<uint8_t> &data)
       ESP_LOGD(TAG, "Failed to get controller.");
       return;
     }
+    if (millis() - this->last_time_set_ > 24 * 60 * 60 * 1000) {
+      // Set time on heater once per day
+      auto now = id(ha_time).now();
+      if (now.is_valid()) {
+        this->sent_requests(this->controller_->gen_time_command(now.hour, now.minute))
+        this->last_time_set_ = millis();
+      }
+    }
   }
 
   bool ret = ResponseParser::parse(data, this->state_);

--- a/components/diesel_heater_ble/heater.cpp
+++ b/components/diesel_heater_ble/heater.cpp
@@ -14,6 +14,7 @@ void DieselHeaterBLE::loop() {
       uint8_t data[8] = {0xaa, 0x55, 0x0c, 0x22, 0x01, 0x00, 0x00, 0x2f};
       this->ble_write_chr(this->parent()->get_gattc_if(), this->parent()->get_remote_bda(), this->handle_, data,
                           sizeof(data));
+      this->update_time();
     }
     this->update_sensors(this->state_);
   }
@@ -110,14 +111,6 @@ void DieselHeaterBLE::on_notification_received(const std::vector<uint8_t> &data)
     if (this->controller_ == nullptr) {
       ESP_LOGD(TAG, "Failed to get controller.");
       return;
-    }
-    if (millis() - this->last_time_set_ > 24 * 60 * 60 * 1000 && this->time_ != nullptr) {
-      // Set time on heater once per day
-      auto now = this->time_->now();
-      if (now.is_valid()) {
-        this->sent_requests(this->controller_->gen_time_command(now.hour, now.minute));
-        this->last_time_set_ = millis();
-      }
     }
   }
 
@@ -229,6 +222,22 @@ void DieselHeaterBLE::update_sensors(const HeaterState &new_state) {
   if (automatic_heating_ != nullptr && automatic_heating_->state != new_state.automaticheating) {
     automatic_heating_->publish_state(new_state.automaticheating);
     return;
+  }
+}
+
+void DieselHeaterBLE::update_time() {
+  if (this->controller_ == nullptr) {
+    return;
+  }
+  if (millis() - this->last_time_set_ > 60 * 60 * 1000 && this->time_ != nullptr) {
+    // Set time on heater once per hour
+    ESP_LOGD(TAG, "Attempting to set time on heater.");
+    auto now = this->time_->now();
+    if (now.is_valid()) {
+      ESP_LOGD(TAG, "Current time: %02d:%02d", now.hour, now.minute);
+      this->sent_requests(this->controller_->gen_time_command(now.hour, now.minute));
+      this->last_time_set_ = millis();
+    }
   }
 }
 

--- a/components/diesel_heater_ble/heater.cpp
+++ b/components/diesel_heater_ble/heater.cpp
@@ -111,11 +111,11 @@ void DieselHeaterBLE::on_notification_received(const std::vector<uint8_t> &data)
       ESP_LOGD(TAG, "Failed to get controller.");
       return;
     }
-    if (millis() - this->last_time_set_ > 24 * 60 * 60 * 1000) {
+    if (millis() - this->last_time_set_ > 24 * 60 * 60 * 1000 && this->time_ != nullptr) {
       // Set time on heater once per day
-      auto now = id(ha_time).now();
+      auto now = this->time_->now();
       if (now.is_valid()) {
-        this->sent_requests(this->controller_->gen_time_command(now.hour, now.minute))
+        this->sent_requests(this->controller_->gen_time_command(now.hour, now.minute));
         this->last_time_set_ = millis();
       }
     }

--- a/components/diesel_heater_ble/heater.h
+++ b/components/diesel_heater_ble/heater.h
@@ -48,6 +48,7 @@ class DieselHeaterBLE : public Component, public ble_client::BLEClientNode {
 
   void on_notification_received(const std::vector<uint8_t> &data);
   void update_sensors(const HeaterState &new_state);
+  void update_time();
 
   void set_time(esphome::time::RealTimeClock *t) { time_ = t; }
 

--- a/components/diesel_heater_ble/heater.h
+++ b/components/diesel_heater_ble/heater.h
@@ -11,6 +11,7 @@
 #include "esphome/components/number/number.h"
 #include "esphome/components/switch/switch.h"
 #include "esphome/components/button/button.h"
+#include "esphome/components/time/real_time_clock.h"
 #include "esphome/core/component.h"
 #include "esphome/core/log.h"
 
@@ -47,6 +48,8 @@ class DieselHeaterBLE : public Component, public ble_client::BLEClientNode {
 
   void on_notification_received(const std::vector<uint8_t> &data);
   void update_sensors(const HeaterState &new_state);
+
+  void set_time(esphome::time::RealTimeClock *t) { time_ = t; }
 
   // Sensor setters
   void set_running_state(sensor::Sensor *sensor) { running_state_ = sensor; }
@@ -110,6 +113,7 @@ class DieselHeaterBLE : public Component, public ble_client::BLEClientNode {
   uint32_t last_request_{0};
   uint32_t last_update_{0};
   uint32_t last_time_set_{0};
+  esphome::time::RealTimeClock *time_{nullptr};
 
   // Sensor fields
   sensor::Sensor *running_state_{};

--- a/components/diesel_heater_ble/heater.h
+++ b/components/diesel_heater_ble/heater.h
@@ -109,6 +109,7 @@ class DieselHeaterBLE : public Component, public ble_client::BLEClientNode {
   bool response_received_{false};
   uint32_t last_request_{0};
   uint32_t last_update_{0};
+  uint32_t last_time_set_{0};
 
   // Sensor fields
   sensor::Sensor *running_state_{};

--- a/esphome.yaml
+++ b/esphome.yaml
@@ -28,6 +28,10 @@ ble_client:
   id: ble_client_id
   mac_address: E0:4E:7A:89:68:D6
 
+time:
+  - platform: homeassistant
+    id: ha_time
+
 diesel_heater_ble:
   ble_client_id: ble_client_id
 

--- a/esphome.yaml
+++ b/esphome.yaml
@@ -34,6 +34,7 @@ time:
 
 diesel_heater_ble:
   ble_client_id: ble_client_id
+  time_id: ha_time
 
 sensor:
   platform: diesel_heater_ble


### PR DESCRIPTION
I noticed the main apk code sets the clock time upon connecting to the heater, and since my heater's clock drifts significantly, I decided to try to implement this here.

That said, my heater doesn't seem to accept the command, as it never changes the time even when the main app sends the set time command. I suspect it's due to a protocol/versioning difference of the heater itself, so I decided to create a draft PR in case others want to test it with their own heater since I've already put in the work anyway.

@warehog if you're able to test this on yours since it's a different protocol I'd love to know if it works or not.