### PR TITLE
Fix scaling precision

### DIFF
--- a/components/diesel_heater_ble/messages.h
+++ b/components/diesel_heater_ble/messages.h
@@ -89,10 +89,10 @@ class ResponseParser {
     }
 
     if (heater_class == HeaterClass::HEATER_AA_55 || heater_class == HeaterClass::HEATER_AA_66) {
-      state.supplyvoltage = (decrypted[11] + (decrypted[12] << 8)) / 10;
+      state.supplyvoltage = static_cast<float>((decrypted[11] + (decrypted[12] << 8))) / 10.0f;
     } else if (heater_class == HeaterClass::HEATER_AA_55_ENCRYPTED ||
-               heater_class == HeaterClass::HEATER_AA_66_ENCRYPTED) {
-      state.supplyvoltage = (decrypted[12] + (decrypted[11] << 8)) / 10;
+           heater_class == HeaterClass::HEATER_AA_66_ENCRYPTED) {
+      state.supplyvoltage = static_cast<float>((decrypted[12] + (decrypted[11] << 8))) / 10.0f;
     }
 
     if (heater_class == HeaterClass::HEATER_AA_55 || heater_class == HeaterClass::HEATER_AA_66) {
@@ -101,7 +101,7 @@ class ResponseParser {
     } else if (heater_class == HeaterClass::HEATER_AA_55_ENCRYPTED ||
                heater_class == HeaterClass::HEATER_AA_66_ENCRYPTED) {
       state.casetemp = (decrypted[14] + (decrypted[13] << 8));
-      state.cabtemp = (decrypted[33] + (decrypted[32] << 8)) / 10;
+      state.cabtemp = (decrypted[33] + (decrypted[32] << 8)) / 10.0f;
     }
 
     // encrypted types only

--- a/components/diesel_heater_ble/state.h
+++ b/components/diesel_heater_ble/state.h
@@ -25,9 +25,9 @@ class HeaterState {
   uint8_t runningmode;
   uint8_t setlevel;
   uint8_t settemp;
-  uint16_t supplyvoltage;
+  float supplyvoltage;
   uint16_t casetemp;
-  uint16_t cabtemp;
+  float cabtemp;
 
   // encoded types only
   uint16_t sttime;


### PR DESCRIPTION
I noticed that the supply voltage values were truncated, it would jump between 12.0 and 13.0 when running for example.

This PR fixes this by ensuring the values are typed as floats so the precision is kept after scaling.

Now HA correctly shows the supply voltage with 1dp of precision, eg 12.8v

I included cab temp as it technically could have 1dp precision on encrypted units, but this is probably a no-op. And I didn't change the altitude sensor as despite being scaled doesn't seem to actually reflect any dp of precision, nor is it necessary to see that level of precision with altitude imho.