### PR TITLE
Add climate component integration with external sensor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ This code is a one big mess, bit with right tools, it can be readed.
 ## What Has Been Done?
 - Created the diesel_heater_ble Component: Implements the BLE protocol to communicate with the heater controller board.
 - Added Sensors: Supports all settings retrieved from the controller.
-- Introduced Controls: Provides switches, buttons, and number inputs for key features, including:
+- Introduced Controls: Provides a climate entity, switches, buttons, and number inputs for key features, including:
   - Power switch
   - Level-up button
   - Level-down button
@@ -324,6 +324,10 @@ This code is a one big mess, bit with right tools, it can be readed.
   - Temperature-down button
   - Level set (number input)
   - Temperature set (number input)
+  - Climate entity:
+    - Full control over the heater using the native climate UI. Temperature setting adjusts auto setpoint, or manually select one of the fan levels for manual control.
+- Added support for auto climate control using an external temperature sensor provided by HA or the ESP32
+  - Useful for models where the internal temperature control is not accurate, or when the control panel is mounted somewhere different from the area you want to control the temperature of
 - Ensured Extensibility: The component is designed to support future versions of controllers.
 
 
@@ -354,9 +358,6 @@ The BLE stack occupies a significant amount of flash memory. Combined with sever
 
 - **Support for Additional Controllers:**  
   Implement `HeaterController_*` classes for other controller types.
-  
-- **Unified Climate Component:**  
-  Integrate a climate component for standardized control.
   
 - **Code Refactoring:**  
   Allow configuration without buttons, switches, or numbers. Currently, if none of these are defined in the YAML, the C++ compiler complains about missing header files (e.g., `esphome/components/button/button.h`).

--- a/components/diesel_heater_ble/__init__.py
+++ b/components/diesel_heater_ble/__init__.py
@@ -5,6 +5,7 @@ from esphome.const import CONF_ID
 
 CODEOWNERS = ["@warehog"]
 DEPENDENCIES = ["ble_client"]
+AUTO_LOAD = ["sensor", "button", "number", "switch", "climate"]
 
 CONF_DIESEL_HEATER_BLE = "diesel_heater_ble"
 

--- a/components/diesel_heater_ble/climate.cpp
+++ b/components/diesel_heater_ble/climate.cpp
@@ -1,0 +1,347 @@
+#include "climate.h"
+#include "heater.h"
+
+#include <algorithm>
+#include <cmath>
+#include <string>
+
+#ifdef USE_ESP32
+
+namespace esphome {
+namespace diesel_heater_ble {
+
+static const char *TAG = "diesel_heater_climate";
+static const char *const MANUAL_LEVEL_MODES[] = {"Level 1", "Level 2", "Level 3", "Level 4", "Level 5",
+                                                  "Level 6", "Level 7", "Level 8", "Level 9", "Level 10"};
+static constexpr float CLIMATE_MIN_TARGET_C = 8.0f;
+static constexpr float CLIMATE_MAX_TARGET_C = 36.0f;
+static constexpr float CLIMATE_DEFAULT_TARGET_C = 20.0f;
+
+static bool parse_manual_level(StringRef mode, uint8_t &level) {
+  std::string mode_str(mode.c_str(), mode.size());
+  if (mode_str.rfind("Level ", 0) == 0) {
+    mode_str = mode_str.substr(6);
+  }
+  if (mode_str.empty()) {
+    return false;
+  }
+  for (char c : mode_str) {
+    if (c < '0' || c > '9') {
+      return false;
+    }
+  }
+  int value = std::stoi(mode_str);
+  if (value < 1 || value > 10) {
+    return false;
+  }
+  level = static_cast<uint8_t>(value);
+  return true;
+}
+
+static const char *manual_level_mode_name(uint8_t level) {
+  if (level < 1 || level > 10) {
+    return MANUAL_LEVEL_MODES[0];
+  }
+  return MANUAL_LEVEL_MODES[level - 1];
+}
+
+uint8_t DieselHeaterClimate::stage_level_for_error_(float error_c) const {
+  // Proportional starts with the auto-on threshold as an offset, reducing overshoots from higher levels when it turns on
+  int stage = static_cast<int>(std::floor((error_c - this->ext_auto_on_error_c_) * this->ext_stage_gain_));
+  return static_cast<uint8_t>(std::clamp(stage, 1, 10));
+}
+
+bool DieselHeaterClimate::refresh_using_external_(uint32_t now) {
+  const bool was_using_external = this->using_external_;
+  const bool has_recent_sample =
+      this->last_ext_temp_ms_ != 0 &&
+      static_cast<uint32_t>(now - this->last_ext_temp_ms_) <= this->ext_temp_timeout_ms_;
+  this->using_external_ = has_recent_sample;
+  return this->using_external_ != was_using_external;
+}
+
+void DieselHeaterClimate::sync_from_heater(const HeaterState &state) {
+  const bool using_external = this->using_external_;
+
+  if (using_external) {
+    this->current_temperature = this->external_temperature_;
+  } else {
+    this->current_temperature = state.cabtemp;
+  }
+
+  // Allow heater-side target updates when not in external strategy, so remote
+  // control changes are reflected while preserving high-resolution external control.
+  if (!using_external && state.settemp >= CLIMATE_MIN_TARGET_C && state.settemp <= CLIMATE_MAX_TARGET_C) {
+    this->target_temperature = state.settemp;
+  }
+
+  if (std::isnan(this->target_temperature) || this->target_temperature < CLIMATE_MIN_TARGET_C ||
+      this->target_temperature > CLIMATE_MAX_TARGET_C) {
+    this->target_temperature = CLIMATE_DEFAULT_TARGET_C;
+  }
+
+  const bool heater_on = state.runningstate != 0;
+
+  // Mirror device on/off state into our intent, except in external auto where
+  // the device intentionally cycles on/off under our control.
+  if (!(using_external && this->auto_requested_)) {
+    this->climate_heat_requested_ = heater_on;
+  }
+
+  this->mode = (heater_on || this->climate_heat_requested_) ? climate::CLIMATE_MODE_HEAT : climate::CLIMATE_MODE_OFF;
+  this->action = this->is_heating_step_(state.runningstep) ? climate::CLIMATE_ACTION_HEATING : climate::CLIMATE_ACTION_IDLE;
+
+  // Keep user control preference synced with real heater mode, except when running
+  // the external-auto strategy that intentionally uses manual backend levels.
+  if (state.runningmode == 2) {
+    this->auto_requested_ = true;
+  } else if (state.runningmode == 1 && !(using_external && this->auto_requested_)) {
+    this->auto_requested_ = false;
+  }
+
+  if (this->auto_requested_) {
+    this->set_fan_mode_(climate::CLIMATE_FAN_AUTO);
+    this->clear_custom_fan_mode_();
+  } else {
+    this->set_custom_fan_mode_(manual_level_mode_name(static_cast<uint8_t>(state.setlevel)));
+  }
+}
+
+void DieselHeaterClimate::loop() {
+  const uint32_t now = millis();
+  const bool external_usage_changed = this->refresh_using_external_(now);
+
+  if (external_usage_changed && !this->using_external_) {
+    ESP_LOGW(TAG, "External sensor timed out (%u ms), falling back to built-in controls", this->ext_temp_timeout_ms_);
+    if (this->auto_requested_ && this->climate_heat_requested_) {
+      this->heater_->on_power_switch(true);
+      this->heater_->on_temp_number(this->target_temperature);
+    }
+  }
+
+  if (this->climate_heat_requested_ && this->auto_requested_ && this->using_external_) {
+    this->apply_external_control_(false, external_usage_changed);
+  }
+}
+
+void DieselHeaterClimate::set_external_temperature(float temp) {
+  if (std::isnan(temp)) {
+    return;
+  }
+
+  ESP_LOGD(TAG, "External temperature update: %.1f", temp);
+
+  const float temp_c = this->ext_temp_fahrenheit_ ? (temp - 32.0f) * (5.0f / 9.0f) : temp;
+
+  if (!this->using_external_) {
+    ESP_LOGI(TAG, "External sensor active (%.1f°C), using staged external auto when selected", temp_c);
+  }
+
+  const uint32_t now = millis();
+  this->external_temperature_ = temp_c;
+  this->last_ext_temp_ms_ = now;
+  this->using_external_ = true;
+}
+
+void DieselHeaterClimate::apply_external_control_(bool force_start_request, bool bypass_timers) {
+  if (std::isnan(this->external_temperature_) || std::isnan(this->target_temperature)) {
+    return;
+  }
+
+  const uint32_t now = millis();
+
+  if (!bypass_timers &&
+      static_cast<uint32_t>(now - this->last_level_update_ms_) < this->ext_level_update_interval_ms_) {
+    return;
+  }
+
+  const float error = this->target_temperature - this->external_temperature_;
+  const bool min_on_satisfied =
+      bypass_timers || this->last_heat_transition_ms_ == 0 ||
+      static_cast<uint32_t>(now - this->last_heat_transition_ms_) >= this->ext_min_on_time_ms_;
+  const bool min_off_satisfied =
+      bypass_timers || this->last_heat_transition_ms_ == 0 ||
+      static_cast<uint32_t>(now - this->last_heat_transition_ms_) >= this->ext_min_off_time_ms_;
+
+  bool heater_on = this->heater_->get_state().runningstate != 0;
+
+  if (!heater_on) {
+    const bool allowed_by_error = force_start_request ? (error > 0.0f) : (error >= this->ext_auto_on_error_c_);
+    if (!allowed_by_error || !min_off_satisfied) {
+      this->last_level_update_ms_ = now;
+      return;
+    }
+
+    ESP_LOGD(TAG, "External auto start: ext=%.1f target=%.1f error=%.2f", this->external_temperature_,
+             this->target_temperature, error);
+    this->heater_->on_power_switch(true);
+    heater_on = true;
+    this->last_heat_transition_ms_ = now;
+    this->overshoot_start_ms_ = 0;
+  }
+
+  // If running, check virtual off condition with hysteresis + dwell timers.
+  if (error <= this->ext_off_error_c_) {
+    if (this->overshoot_start_ms_ == 0) {
+      this->overshoot_start_ms_ = now;
+    }
+  } else {
+    this->overshoot_start_ms_ = 0;
+  }
+
+  const bool overshoot_hold_satisfied =
+      (this->overshoot_start_ms_ != 0) &&
+    (bypass_timers || static_cast<uint32_t>(now - this->overshoot_start_ms_) >= this->ext_overshoot_hold_ms_);
+
+  if (heater_on && min_on_satisfied && overshoot_hold_satisfied) {
+    ESP_LOGD(TAG, "External auto idle: ext=%.1f target=%.1f error=%.2f", this->external_temperature_,
+             this->target_temperature, error);
+    this->heater_->on_power_switch(false);
+    this->last_heat_transition_ms_ = now;
+    this->overshoot_start_ms_ = 0;
+    this->last_level_update_ms_ = now;
+    return;
+  }
+
+  if (!heater_on) {
+    this->last_level_update_ms_ = now;
+    return;
+  }
+
+  const uint8_t level = this->stage_level_for_error_(error);
+  if (this->last_commanded_level_ != level) {
+    ESP_LOGD(TAG, "External staged control: ext=%.1f target=%.1f error=%.2f -> level %u", this->external_temperature_,
+             this->target_temperature, error, level);
+  }
+
+  this->heater_->on_power_level_number(level);
+  this->last_commanded_level_ = level;
+  this->last_level_update_ms_ = now;
+}
+
+void DieselHeaterClimate::setup() {
+  if (this->heater_ == nullptr) {
+    ESP_LOGE(TAG, "Heater not set for climate component!");
+    return;
+  }
+
+  this->set_supported_custom_fan_modes(MANUAL_LEVEL_MODES);
+
+  HeaterState state = this->heater_->get_state();
+  this->sync_from_heater(state);
+
+  ESP_LOGD(TAG, "Climate initialized. Mode: %d, Temp: %.1f, Running: %d, Running mode: %d", static_cast<int>(this->mode),
+           this->target_temperature, state.runningstate, state.runningmode);
+
+  this->publish_state();
+}
+
+climate::ClimateTraits DieselHeaterClimate::traits() {
+  auto traits = climate::ClimateTraits();
+
+  traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE | climate::CLIMATE_SUPPORTS_ACTION);
+  traits.set_supported_modes({
+      climate::CLIMATE_MODE_OFF,
+      climate::CLIMATE_MODE_HEAT,
+  });
+  traits.set_supported_fan_modes({
+      climate::CLIMATE_FAN_AUTO,
+  });
+  traits.set_visual_min_temperature(CLIMATE_MIN_TARGET_C);
+  traits.set_visual_max_temperature(CLIMATE_MAX_TARGET_C);
+  traits.set_visual_temperature_step(1.0f);
+
+  return traits;
+}
+
+void DieselHeaterClimate::control(const climate::ClimateCall &call) {
+  if (this->heater_ == nullptr) {
+    ESP_LOGW(TAG, "Heater not set for climate component");
+    return;
+  }
+
+  if (call.get_mode().has_value()) {
+    climate::ClimateMode new_mode = *call.get_mode();
+    ESP_LOGD(TAG, "Mode change requested: %d", static_cast<int>(new_mode));
+
+    if (new_mode == climate::CLIMATE_MODE_OFF) {
+      this->climate_heat_requested_ = false;
+      this->mode = climate::CLIMATE_MODE_OFF;
+      this->heater_->on_power_switch(false);
+    } else {
+      this->climate_heat_requested_ = true;
+      this->mode = climate::CLIMATE_MODE_HEAT;
+
+      if (this->auto_requested_ && this->using_external_) {
+        this->apply_external_control_(true, true);
+      } else if (this->auto_requested_) {
+        this->heater_->on_power_switch(true);
+        this->heater_->on_temp_number(this->target_temperature);
+      } else {
+        this->heater_->on_power_switch(true);
+      }
+    }
+  }
+
+  if (call.get_fan_mode().has_value()) {
+    auto fan_mode = *call.get_fan_mode();
+    if (fan_mode == climate::CLIMATE_FAN_AUTO) {
+      this->auto_requested_ = true;
+
+      if (this->climate_heat_requested_) {
+        if (this->using_external_) {
+          this->apply_external_control_(false, true);
+        } else {
+          this->heater_->on_power_switch(true);
+          this->heater_->on_temp_number(this->target_temperature);
+        }
+      }
+    }
+  }
+
+  if (call.has_custom_fan_mode()) {
+    auto custom_mode = call.get_custom_fan_mode();
+    uint8_t level = 0;
+    if (parse_manual_level(custom_mode, level)) {
+      this->auto_requested_ = false;
+      if (this->climate_heat_requested_) {
+        this->heater_->on_power_switch(true);
+        this->heater_->on_power_level_number(level);
+      }
+      this->last_commanded_level_ = level;
+      ESP_LOGD(TAG, "Manual level override: %u", level);
+    } else {
+      ESP_LOGW(TAG, "Invalid manual level fan mode: %.*s", static_cast<int>(custom_mode.size()), custom_mode.c_str());
+    }
+  }
+
+  if (call.get_target_temperature().has_value()) {
+    float new_temp = *call.get_target_temperature();
+    this->target_temperature = std::clamp(new_temp, CLIMATE_MIN_TARGET_C, CLIMATE_MAX_TARGET_C);
+    this->auto_requested_ = true;
+
+    if (!this->climate_heat_requested_) {
+      ESP_LOGD(TAG, "Target update %.1f while OFF: storing only, not waking heater", this->target_temperature);
+      this->publish_state();
+      return;
+    }
+
+    if (this->auto_requested_) {
+      if (this->using_external_) {
+        ESP_LOGD(TAG, "Target update %.1f in staged external auto", this->target_temperature);
+        this->apply_external_control_(false, true);
+      } else {
+        ESP_LOGD(TAG, "Target update %.1f in internal auto", this->target_temperature);
+        this->heater_->on_power_switch(true);
+        this->heater_->on_temp_number(this->target_temperature);
+      }
+    }
+  }
+
+  this->publish_state();
+}
+
+}  // namespace diesel_heater_ble
+}  // namespace esphome
+
+#endif  // USE_ESP32

--- a/components/diesel_heater_ble/climate.cpp
+++ b/components/diesel_heater_ble/climate.cpp
@@ -53,9 +53,11 @@ uint8_t DieselHeaterClimate::stage_level_for_error_(float error_c) const {
 
 bool DieselHeaterClimate::refresh_using_external_(uint32_t now) {
   const bool was_using_external = this->using_external_;
+  const bool is_heating = this->heater_->get_state().runningstate != 0;
+  const u_int32_t timeout = is_heating ? this->ext_temp_timeout_heating_ms_ : this->ext_temp_timeout_ms_;
   const bool has_recent_sample =
       this->last_ext_temp_ms_ != 0 &&
-      static_cast<uint32_t>(now - this->last_ext_temp_ms_) <= this->ext_temp_timeout_ms_;
+      static_cast<uint32_t>(now - this->last_ext_temp_ms_) <= timeout;
   this->using_external_ = has_recent_sample;
   return this->using_external_ != was_using_external;
 }
@@ -112,7 +114,7 @@ void DieselHeaterClimate::loop() {
   const bool external_usage_changed = this->refresh_using_external_(now);
 
   if (external_usage_changed && !this->using_external_) {
-    ESP_LOGW(TAG, "External sensor timed out (%u ms), falling back to built-in controls", this->ext_temp_timeout_ms_);
+    ESP_LOGW(TAG, "External sensor timed out (%u ms), falling back to built-in controls", now - this->last_ext_temp_ms_);
     if (this->auto_requested_ && this->climate_heat_requested_) {
       this->heater_->on_power_switch(true);
       this->heater_->on_temp_number(this->target_temperature);

--- a/components/diesel_heater_ble/climate.cpp
+++ b/components/diesel_heater_ble/climate.cpp
@@ -92,7 +92,7 @@ void DieselHeaterClimate::sync_from_heater(const HeaterState &state) {
 
   this->mode = (heater_on || this->climate_heat_requested_) ? climate::CLIMATE_MODE_HEAT : climate::CLIMATE_MODE_OFF;
   if (this->mode == climate::CLIMATE_MODE_OFF) {
-    this->action = climate::CLIMATE_ACTION_OFF
+    this->action = climate::CLIMATE_ACTION_OFF;
   } else {
     this->action = this->is_heating_step_(state.runningstep) ? climate::CLIMATE_ACTION_HEATING : climate::CLIMATE_ACTION_IDLE;
   }

--- a/components/diesel_heater_ble/climate.cpp
+++ b/components/diesel_heater_ble/climate.cpp
@@ -91,7 +91,11 @@ void DieselHeaterClimate::sync_from_heater(const HeaterState &state) {
   }
 
   this->mode = (heater_on || this->climate_heat_requested_) ? climate::CLIMATE_MODE_HEAT : climate::CLIMATE_MODE_OFF;
-  this->action = this->is_heating_step_(state.runningstep) ? climate::CLIMATE_ACTION_HEATING : climate::CLIMATE_ACTION_IDLE;
+  if (this->mode == climate::CLIMATE_MODE_OFF) {
+    this->action = climate::CLIMATE_ACTION_OFF
+  } else {
+    this->action = this->is_heating_step_(state.runningstep) ? climate::CLIMATE_ACTION_HEATING : climate::CLIMATE_ACTION_IDLE;
+  }
 
   // Keep user control preference synced with real heater mode, except when running
   // the external-auto strategy that intentionally uses manual backend levels.

--- a/components/diesel_heater_ble/climate.h
+++ b/components/diesel_heater_ble/climate.h
@@ -30,6 +30,7 @@ class DieselHeaterClimate : public climate::Climate, public Component {
   /// How long to wait without an external reading before falling back to the heater's
   /// built-in auto mode. Configured via external_temperature_timeout in YAML.
   void set_external_temperature_timeout(uint32_t timeout_ms) { this->ext_temp_timeout_ms_ = timeout_ms; }
+  void set_external_temperature_timeout_heating(uint32_t timeout_ms) { this->ext_temp_timeout_heating_ms_ = timeout_ms; }
 
   /// When true, incoming external temperatures are converted from °F to °C before use.
   void set_external_temperature_fahrenheit(bool use_f) { this->ext_temp_fahrenheit_ = use_f; }
@@ -56,7 +57,8 @@ class DieselHeaterClimate : public climate::Climate, public Component {
 
   // External temperature control state
   float external_temperature_{NAN};
-  uint32_t ext_temp_timeout_ms_{5 * 60 * 1000};  // default 5 minutes; override via YAML
+  uint32_t ext_temp_timeout_ms_{2 * 60 * 60 * 1000};  // default 2 hours; override via YAML
+  uint32_t ext_temp_timeout_heating_ms_{15 * 60 * 1000};  // default 15 minutes; override via YAML
   uint32_t last_ext_temp_ms_{0};                 // 0 = never received
   uint32_t last_level_update_ms_{0};
   bool ext_temp_fahrenheit_{false};

--- a/components/diesel_heater_ble/climate.h
+++ b/components/diesel_heater_ble/climate.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#ifdef USE_ESP32
+
+#include "esphome/components/climate/climate.h"
+#include "esphome/core/component.h"
+
+namespace esphome {
+namespace diesel_heater_ble {
+
+class DieselHeaterBLE;
+struct HeaterState;
+
+class DieselHeaterClimate : public climate::Climate, public Component {
+ public:
+  DieselHeaterClimate() = default;
+  ~DieselHeaterClimate() = default;
+
+  void setup() override;
+  void loop() override;
+  void sync_from_heater(const HeaterState &state);
+
+  void set_heater(DieselHeaterBLE *heater) { this->heater_ = heater; }
+
+  /// Called from a sensor's on_value lambda to supply an external temperature reading.
+  /// When called, the component uses staged proportional control to drive manual heater levels
+  /// instead of relying on the heater's built-in thermostat.
+  void set_external_temperature(float temp);
+
+  /// How long to wait without an external reading before falling back to the heater's
+  /// built-in auto mode. Configured via external_temperature_timeout in YAML.
+  void set_external_temperature_timeout(uint32_t timeout_ms) { this->ext_temp_timeout_ms_ = timeout_ms; }
+
+  /// When true, incoming external temperatures are converted from °F to °C before use.
+  void set_external_temperature_fahrenheit(bool use_f) { this->ext_temp_fahrenheit_ = use_f; }
+  void set_external_stage_gain(float gain) { this->ext_stage_gain_ = gain; }
+  void set_external_off_error(float error_c) { this->ext_off_error_c_ = error_c; }
+  void set_external_auto_on_error(float error_c) { this->ext_auto_on_error_c_ = error_c; }
+  void set_external_min_on_time(uint32_t ms) { this->ext_min_on_time_ms_ = ms; }
+  void set_external_min_off_time(uint32_t ms) { this->ext_min_off_time_ms_ = ms; }
+  void set_external_overshoot_hold(uint32_t ms) { this->ext_overshoot_hold_ms_ = ms; }
+  void set_external_level_update_interval(uint32_t ms) { this->ext_level_update_interval_ms_ = ms; }
+
+ protected:
+  void control(const climate::ClimateCall &call) override;
+  climate::ClimateTraits traits() override;
+  uint8_t stage_level_for_error_(float error_c) const;
+
+  /// Run staged external-auto control; force_start_request is used for explicit
+  /// user HEAT requests and bypass_timers is used for user-driven changes.
+  void apply_external_control_(bool force_start_request, bool bypass_timers);
+  bool refresh_using_external_(uint32_t now);
+  bool is_heating_step_(uint8_t running_step) const { return running_step == 2 || running_step == 3; }
+
+  DieselHeaterBLE *heater_;
+
+  // External temperature control state
+  float external_temperature_{NAN};
+  uint32_t ext_temp_timeout_ms_{5 * 60 * 1000};  // default 5 minutes; override via YAML
+  uint32_t last_ext_temp_ms_{0};                 // 0 = never received
+  uint32_t last_level_update_ms_{0};
+  bool ext_temp_fahrenheit_{false};
+  // Primary state axes:
+  // using_external_: external sensor freshness/availability state.
+  // auto_requested_: user intent for auto vs manual-level control.
+  bool using_external_{false};
+  bool auto_requested_{true};
+  // Separate climate on/off intent so mode persistence is decoupled from auto/manual preference.
+  bool climate_heat_requested_{false};
+
+  uint8_t last_commanded_level_{1};
+  uint32_t last_heat_transition_ms_{0};
+  uint32_t overshoot_start_ms_{0};
+
+  // Staged external-auto parameters.
+  float ext_stage_gain_{2.0f};
+  float ext_off_error_c_{-0.5f};
+  float ext_auto_on_error_c_{1.0f};
+  uint32_t ext_min_on_time_ms_{10 * 60 * 1000};
+  uint32_t ext_min_off_time_ms_{20 * 60 * 1000};
+  uint32_t ext_overshoot_hold_ms_{3 * 60 * 1000};
+  uint32_t ext_level_update_interval_ms_{10 * 1000};
+};
+
+}  // namespace diesel_heater_ble
+}  // namespace esphome
+
+#endif  // USE_ESP32

--- a/components/diesel_heater_ble/climate.py
+++ b/components/diesel_heater_ble/climate.py
@@ -1,0 +1,62 @@
+import esphome.codegen as cg
+from esphome.components import climate
+import esphome.config_validation as cv
+
+from . import CONF_DIESEL_HEATER_BLE, DieselHeaterBLE, diesel_heater_ble_ns
+
+CODEOWNERS = ["@warehog"]
+DEPENDENCIES = ["diesel_heater_ble"]
+AUTO_LOAD = ["climate"]
+
+DieselHeaterClimate = diesel_heater_ble_ns.class_(
+    "DieselHeaterClimate", climate.Climate, cg.Component
+)
+
+CONF_EXTERNAL_TEMPERATURE_TIMEOUT = "external_temperature_timeout"
+CONF_EXTERNAL_USE_FAHRENHEIT = "external_temperature_fahrenheit"
+CONF_EXTERNAL_STAGE_GAIN = "external_stage_gain"
+CONF_EXTERNAL_OFF_ERROR = "external_off_error"
+CONF_EXTERNAL_AUTO_ON_ERROR = "external_auto_on_error"
+CONF_EXTERNAL_MIN_ON_TIME = "external_min_on_time"
+CONF_EXTERNAL_MIN_OFF_TIME = "external_min_off_time"
+CONF_EXTERNAL_OVERSHOOT_HOLD = "external_overshoot_hold"
+CONF_EXTERNAL_LEVEL_UPDATE_INTERVAL = "external_level_update_interval"
+
+CONFIG_SCHEMA = (
+    climate.climate_schema(DieselHeaterClimate)
+    .extend(
+        {
+            cv.GenerateID(CONF_DIESEL_HEATER_BLE): cv.use_id(DieselHeaterBLE),
+            cv.Optional(
+                CONF_EXTERNAL_TEMPERATURE_TIMEOUT, default="5min"
+            ): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_EXTERNAL_USE_FAHRENHEIT, default=False): cv.boolean,
+            cv.Optional(CONF_EXTERNAL_STAGE_GAIN, default=2.0): cv.float_range(min=0.01),
+            cv.Optional(CONF_EXTERNAL_OFF_ERROR, default=-0.5): cv.float_,
+            cv.Optional(CONF_EXTERNAL_AUTO_ON_ERROR, default=1.0): cv.float_,
+            cv.Optional(CONF_EXTERNAL_MIN_ON_TIME, default="10min"): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_EXTERNAL_MIN_OFF_TIME, default="20min"): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_EXTERNAL_OVERSHOOT_HOLD, default="3min"): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_EXTERNAL_LEVEL_UPDATE_INTERVAL, default="10s"): cv.positive_time_period_milliseconds,
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+
+async def to_code(config):
+    var = await climate.new_climate(config)
+    await cg.register_component(var, config)
+
+    parent = await cg.get_variable(config[CONF_DIESEL_HEATER_BLE])
+    cg.add(var.set_heater(parent))
+    cg.add(parent.set_climate(var))
+    cg.add(var.set_external_temperature_timeout(config[CONF_EXTERNAL_TEMPERATURE_TIMEOUT]))
+    cg.add(var.set_external_temperature_fahrenheit(config[CONF_EXTERNAL_USE_FAHRENHEIT]))
+    cg.add(var.set_external_stage_gain(config[CONF_EXTERNAL_STAGE_GAIN]))
+    cg.add(var.set_external_off_error(config[CONF_EXTERNAL_OFF_ERROR]))
+    cg.add(var.set_external_auto_on_error(config[CONF_EXTERNAL_AUTO_ON_ERROR]))
+    cg.add(var.set_external_min_on_time(config[CONF_EXTERNAL_MIN_ON_TIME]))
+    cg.add(var.set_external_min_off_time(config[CONF_EXTERNAL_MIN_OFF_TIME]))
+    cg.add(var.set_external_overshoot_hold(config[CONF_EXTERNAL_OVERSHOOT_HOLD]))
+    cg.add(var.set_external_level_update_interval(config[CONF_EXTERNAL_LEVEL_UPDATE_INTERVAL]))

--- a/components/diesel_heater_ble/climate.py
+++ b/components/diesel_heater_ble/climate.py
@@ -13,6 +13,7 @@ DieselHeaterClimate = diesel_heater_ble_ns.class_(
 )
 
 CONF_EXTERNAL_TEMPERATURE_TIMEOUT = "external_temperature_timeout"
+CONF_EXTERNAL_TEMPERATURE_TIMEOUT_HEATING = "external_temperature_timeout_heating"
 CONF_EXTERNAL_USE_FAHRENHEIT = "external_temperature_fahrenheit"
 CONF_EXTERNAL_STAGE_GAIN = "external_stage_gain"
 CONF_EXTERNAL_OFF_ERROR = "external_off_error"
@@ -28,7 +29,10 @@ CONFIG_SCHEMA = (
         {
             cv.GenerateID(CONF_DIESEL_HEATER_BLE): cv.use_id(DieselHeaterBLE),
             cv.Optional(
-                CONF_EXTERNAL_TEMPERATURE_TIMEOUT, default="5min"
+                CONF_EXTERNAL_TEMPERATURE_TIMEOUT, default="2h"
+            ): cv.positive_time_period_milliseconds,
+            cv.Optional(
+                CONF_EXTERNAL_TEMPERATURE_TIMEOUT_HEATING, default="15min"
             ): cv.positive_time_period_milliseconds,
             cv.Optional(CONF_EXTERNAL_USE_FAHRENHEIT, default=False): cv.boolean,
             cv.Optional(CONF_EXTERNAL_STAGE_GAIN, default=2.0): cv.float_range(min=0.01),
@@ -52,6 +56,7 @@ async def to_code(config):
     cg.add(var.set_heater(parent))
     cg.add(parent.set_climate(var))
     cg.add(var.set_external_temperature_timeout(config[CONF_EXTERNAL_TEMPERATURE_TIMEOUT]))
+    cg.add(var.set_external_temperature_timeout_heating(config[CONF_EXTERNAL_TEMPERATURE_TIMEOUT_HEATING]))
     cg.add(var.set_external_temperature_fahrenheit(config[CONF_EXTERNAL_USE_FAHRENHEIT]))
     cg.add(var.set_external_stage_gain(config[CONF_EXTERNAL_STAGE_GAIN]))
     cg.add(var.set_external_off_error(config[CONF_EXTERNAL_OFF_ERROR]))

--- a/components/diesel_heater_ble/heater.cpp
+++ b/components/diesel_heater_ble/heater.cpp
@@ -1,4 +1,5 @@
 #include "heater.h"
+#include "climate.h"
 
 #ifdef USE_ESP32
 
@@ -120,7 +121,19 @@ void DieselHeaterBLE::on_notification_received(const std::vector<uint8_t> &data)
   }
 }
 
+void DieselHeaterBLE::update_climate(const HeaterState &new_state) {
+  if (this->climate_ == nullptr) {
+    return;
+  }
+
+  this->climate_->sync_from_heater(new_state);
+
+  this->climate_->publish_state();
+}
+
 void DieselHeaterBLE::update_sensors(const HeaterState &new_state) {
+  this->update_climate(new_state);
+
   if (running_state_ != nullptr && running_state_->state != new_state.runningstate) {
     if (this->power_switch_ != nullptr) {
       this->power_switch_->publish_state(new_state.runningstate);

--- a/components/diesel_heater_ble/heater.h
+++ b/components/diesel_heater_ble/heater.h
@@ -21,6 +21,8 @@
 namespace esphome {
 namespace diesel_heater_ble {
 
+class DieselHeaterClimate;
+
 class DieselHeaterBLE : public Component, public ble_client::BLEClientNode {
  public:
   DieselHeaterBLE() = default;
@@ -46,6 +48,7 @@ class DieselHeaterBLE : public Component, public ble_client::BLEClientNode {
   bool ble_register_for_notify(esp_gatt_if_t gattc_if, esp_bd_addr_t remote_bda);
 
   void on_notification_received(const std::vector<uint8_t> &data);
+  void update_climate(const HeaterState &new_state);
   void update_sensors(const HeaterState &new_state);
 
   // Sensor setters
@@ -93,6 +96,9 @@ class DieselHeaterBLE : public Component, public ble_client::BLEClientNode {
   // Switch setter
   void set_power_switch(switch_::Switch *sw) { power_switch_ = sw; }
   void on_power_switch(bool state);
+
+  // Climate setter
+  void set_climate(DieselHeaterClimate *climate) { climate_ = climate; }
 
   HeaterState get_state() { return this->state_; }
 
@@ -143,6 +149,8 @@ class DieselHeaterBLE : public Component, public ble_client::BLEClientNode {
   number::Number *set_temp_number_{};
 
   switch_::Switch *power_switch_{};
+
+  DieselHeaterClimate *climate_{};
 };
 
 }  // namespace diesel_heater_ble

--- a/esphome.yaml
+++ b/esphome.yaml
@@ -12,15 +12,20 @@ esp32:
 # Enable logging
 logger:
 
+api:
+
 wifi:
   networks:
     - ssid: <ssid>
       password: <password>
 
 external_components:
-  - source: github://warehog/esphome-diesel-heater-ble@main
-    refresh: 0s
-    components: [diesel_heater_ble]
+  # - source: github://carleeno/esphome-diesel-heater-ble@main
+  #   refresh: 0s
+  #   components: [diesel_heater_ble]
+  - source:
+      type: local
+      path: components
 
 esp32_ble_tracker:
 
@@ -31,74 +36,97 @@ ble_client:
 diesel_heater_ble:
   ble_client_id: ble_client_id
 
+climate:
+  - platform: diesel_heater_ble
+    name: "Diesel Heater"
+    id: diesel_heater_climate
+    external_temperature_timeout: 5min
+    external_temperature_fahrenheit: false
+    external_stage_gain: 2.0                # levels per degree C
+    external_off_error: -0.5                # degrees C (negative error = over temp setpoint)
+    external_auto_on_error: 1.0             # degrees C (positive error = under temp setpoint)
+    external_min_on_time: 10min             # minimum time to stay on once turned on
+    external_min_off_time: 20min            # minimum time to stay off once turned off
+    external_overshoot_hold: 3min           # time to hold overshoot before turning off
+    external_level_update_interval: 10s     # minimum interval to update level
+
 sensor:
-  platform: diesel_heater_ble
-  running_state:
-    name: "Running State"
-    id: running_state
-  error_code:
-    name: "Error Code"
-    id: error_code
-  running_step:
-    name: "Running Step"
-    id: running_step
-  altitude:
-    name: "Altitude"
-    id: altitude
-  running_mode:
-    name: "Running Mode"
-    id: running_mode
-  set_level:
-    name: "Set Level"
-    id: set_level
-  set_temp:
-    name: "Set Temp"
-    id: set_temp
-  supply_voltage:
-    name: "Supply Voltage"
-    id: supply_voltage
-  case_temp:
-    name: "Case Temp"
-    id: case_temp
-  cab_temp:
-    name: "Cab Temp"
-    id: cab_temp
-  start_time:
-    name: "Start Time"
-    id: start_time
-  auto_time:
-    name: "Auto Time"
-    id: auto_time
-  run_time:
-    name: "Run Time"
-    id: run_time
-  is_auto:
-    name: "Is Auto"
-    id: is_auto
-  language:
-    name: "Language"
-    id: language
-  temp_offset:
-    name: "Temp Offset"
-    id: temp_offset
-  tank_volume:
-    name: "Tank Volume"
-    id: tank_volume
-  oil_pump_type:
-    name: "Oil Pump Type"
-    id: oil_pump_type
-  rf433_on_off:
-    name: "RF433 On Off"
-    id: rf433_on_off
-  temp_unit:
-    name: "Temp Unit"
-    id: temp_unit
-  altitude_unit:
-    name: "Altitude Unit"
-    id: altitude_unit
-  automatic_heating:
-    name: "Automatic Heating"
-    id: automatic_heating
+  - platform: homeassistant
+    entity_id: sensor.my_external_temperature
+    id: my_external_temperature
+    filters:
+      - throttle: 10s
+      - heartbeat: 30s    # must be shorter than external_temperature_timeout
+      - debounce: 2s
+    on_value:
+      - lambda: id(diesel_heater_climate).set_external_temperature(x);
+  - platform: diesel_heater_ble
+    running_state:
+      name: "Running State"
+      id: running_state
+    error_code:
+      name: "Error Code"
+      id: error_code
+    running_step:
+      name: "Running Step"
+      id: running_step
+    altitude:
+      name: "Altitude"
+      id: altitude
+    running_mode:
+      name: "Running Mode"
+      id: running_mode
+    set_level:
+      name: "Set Level"
+      id: set_level
+    set_temp:
+      name: "Set Temp"
+      id: set_temp
+    supply_voltage:
+      name: "Supply Voltage"
+      id: supply_voltage
+    case_temp:
+      name: "Case Temp"
+      id: case_temp
+    cab_temp:
+      name: "Cab Temp"
+      id: cab_temp
+    start_time:
+      name: "Start Time"
+      id: start_time
+    auto_time:
+      name: "Auto Time"
+      id: auto_time
+    run_time:
+      name: "Run Time"
+      id: run_time
+    is_auto:
+      name: "Is Auto"
+      id: is_auto
+    language:
+      name: "Language"
+      id: language
+    temp_offset:
+      name: "Temp Offset"
+      id: temp_offset
+    tank_volume:
+      name: "Tank Volume"
+      id: tank_volume
+    oil_pump_type:
+      name: "Oil Pump Type"
+      id: oil_pump_type
+    rf433_on_off:
+      name: "RF433 On Off"
+      id: rf433_on_off
+    temp_unit:
+      name: "Temp Unit"
+      id: temp_unit
+    altitude_unit:
+      name: "Altitude Unit"
+      id: altitude_unit
+    automatic_heating:
+      name: "Automatic Heating"
+      id: automatic_heating
   
 number:
   - platform: diesel_heater_ble

--- a/esphome.yaml
+++ b/esphome.yaml
@@ -35,7 +35,7 @@ diesel_heater_ble:
 
 climate:
   - platform: diesel_heater_ble
-    name: "Diesel Heater"
+    name: "Climate"
     id: diesel_heater_climate
     external_temperature_timeout: 2h        # time at which it fall back to internal temperature, even while off/idle
     external_temperature_timeout_heating: 15min # time at which it fall back to internal temperature, while actively heating

--- a/esphome.yaml
+++ b/esphome.yaml
@@ -37,7 +37,8 @@ climate:
   - platform: diesel_heater_ble
     name: "Diesel Heater"
     id: diesel_heater_climate
-    external_temperature_timeout: 5min
+    external_temperature_timeout: 2h        # time at which it fall back to internal temperature, even while off/idle
+    external_temperature_timeout_heating: 15min # time at which it fall back to internal temperature, while actively heating
     external_temperature_fahrenheit: false
     external_stage_gain: 2.0                # levels per degree C
     external_off_error: -0.5                # degrees C (negative error = over temp setpoint)
@@ -52,9 +53,7 @@ sensor:
     entity_id: sensor.my_external_temperature
     id: my_external_temperature
     filters:
-      - throttle: 10s
-      - heartbeat: 30s    # must be shorter than external_temperature_timeout
-      - debounce: 2s
+      - debounce: 10s      # adding heartbeat would defeat the timeout safety as it replays the last seen state endlessly
     on_value:
       - lambda: id(diesel_heater_climate).set_external_temperature(x);
   - platform: diesel_heater_ble

--- a/esphome.yaml
+++ b/esphome.yaml
@@ -20,12 +20,9 @@ wifi:
       password: <password>
 
 external_components:
-  # - source: github://carleeno/esphome-diesel-heater-ble@main
-  #   refresh: 0s
-  #   components: [diesel_heater_ble]
-  - source:
-      type: local
-      path: components
+  - source: github://warehog/esphome-diesel-heater-ble@main
+    refresh: 0s
+    components: [diesel_heater_ble]
 
 esp32_ble_tracker:
 


### PR DESCRIPTION
This pull request introduces a new feature to the `diesel_heater_ble` component: a native climate entity for Home Assistant, enabling full thermostat-style control of diesel heaters, including support for external temperature sensors and advanced auto/manual modes. 

### Major Features and Changes:

**1. Native Climate Entity Integration**
- Added a new `DieselHeaterClimate` class in C++ (`climate.cpp`, `climate.h`) that implements a Home Assistant-compatible climate entity, supporting both auto (thermostat) and manual (fan level) modes, and synchronizing with the heater's BLE state. This enables users to control the heater using the standard climate UI.

**2. External Temperature Sensor Support**
- Implemented logic and configuration to allow the climate entity to use an external temperature sensor (from HA or ESP32) for auto control, including staged proportional control, timeouts, and fallback to internal control if the external sensor is unavailable.

### Testing:

This was tested using my own device, with and without external temperature control. All climate controls work as expected, with the only issues noticed being a minor state mismatch after initially flashing the esp (if it was on external auto control it might initially flip to manual control if it doesn't get an external temperature reading right away)

I will caveat that there are probably failure modes from an external temperature source that this might not catch, such as continuing to get a heartbeat from HA with a stale reading. However I didn't want to force a value change timer as in normal operation the value might not change for hours if the heat output matches the heat loss. However since there's no integral component on the external temperature controller, a stale temperature reading won't cause the heat output to increase, it will simply remain at whatever the last level was.